### PR TITLE
fix(glyph-collector): restore page scrolling on mobile touch screens

### DIFF
--- a/GlyphCollectorUI/GlyphCollectorUI.html
+++ b/GlyphCollectorUI/GlyphCollectorUI.html
@@ -10,9 +10,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Allura&family=Amatic+SC&family=Architects+Daughter&family=Caveat&family=Dancing+Script&family=Gochi+Hand&family=Great+Vibes&family=Handlee&family=Indie+Flower&family=Kalam&family=Pacifico&family=Patrick+Hand&family=Permanent+Marker&family=Pinyon+Script&family=Sacramento&family=Shadows+Into+Light&family=Tangerine&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
-        /* Disable touch actions to prevent scrolling while drawing */
+        /* Keep pull-to-refresh and elastic scroll out of the way,
+           but DO NOT disable touch-action globally — that also blocks
+           page scrolling on mobile. Each .canvas-slot carries its own
+           touch-action: none so drawing stays hijack-free. */
         body {
-            touch-action: none;
             overscroll-behavior: none;
         }
 
@@ -40,8 +42,26 @@
         /* GC11: mobile / tablet layout. Below 900 px wide, switch to a
            single-column, one-variant-at-a-time flow. The toolbar wraps
            aggressively and the settings / coverage panels become
-           full-width sheets pinned to the bottom of the viewport. */
+           full-width sheets pinned to the bottom of the viewport.
+
+           Also: allow the body AND the main drawing area to scroll
+           vertically so a stack of 10 slots remains reachable on a
+           touch screen. Tailwind's h-screen / overflow-hidden on
+           <body> and overflow-y-hidden on <main> would otherwise
+           clamp the viewport to one screenful. */
         @media (max-width: 900px) {
+            html, body {
+                height: auto !important;
+                min-height: 100vh !important;
+                overflow-y: auto !important;
+                overflow-x: hidden !important;
+                -webkit-overflow-scrolling: touch;
+            }
+            main {
+                overflow-y: visible !important;
+                overflow-x: hidden !important;
+                flex: none !important;
+            }
             header { padding: 0.75rem !important; gap: 0.5rem !important; }
             header h1 { font-size: 1rem !important; }
             header button { height: 2.5rem !important; padding: 0.25rem 0.5rem !important; }


### PR DESCRIPTION
## Summary

The GlyphCollector was unscrollable on touch screens (reported
against Firefox on Android). Three overlapping CSS rules were
fighting each other and clamping the viewport to one screenful.

## Root cause

1. `body { touch-action: none }` — blanket-blocked every touch
   gesture on the whole page (scroll, pinch, pull-to-refresh). The
   comment admitted the intent was *prevent scrolling while
   drawing*, but `.canvas-slot` already carries its own
   `touch-action: none`, so the body-level rule was redundant **and**
   over-reaching.
2. Tailwind's `h-screen overflow-hidden` on `<body>` clamps the
   viewport to exactly 100 vh with no scroll container.
3. `<main>` had `overflow-y-hidden`. The GC11 mobile media query
   reflows the grid to a single vertical column of 10 canvases,
   well past any viewport height, with no way to scroll them into
   view.

## Fix

- Drop `touch-action: none` from `body`. Keep
  `overscroll-behavior: none` so pull-to-refresh still won't hijack
  drawing.
- In `@media (max-width: 900px)`, override `html / body` to
  `height: auto`, `min-height: 100vh`, `overflow-y: auto`, with
  `-webkit-overflow-scrolling: touch` for iOS momentum scroll.
- Same block: switch `<main>` to `overflow-y: visible` and drop its
  `flex: 1` so it cooperates with the new body scroller instead of
  competing with it.

## Verification

Playwright at a 412 × 800 Android-ish viewport (touch + mobile
emulation on), Tailwind CDN intercepted with the shim:

| Check | Before | After |
|-------|--------|-------|
| `body` computed `touch-action` | `none` | `auto` |
| `body` computed `overflow-y` | (from Tailwind: `hidden`) | `auto` |
| `document.scrollHeight` | 800 (clamped) | 4767 |
| `window.scrollTo(0, 400)` → `window.scrollY` | 0 | 400 |

Desktop is unaffected: the media query only fires below 900 px
wide, so the desktop layout retains its `h-screen overflow-hidden`
shell. Drawing is still hijack-free because `.canvas-slot` keeps
`touch-action: none` — a touch that starts on a canvas scrolls
nothing; a touch that starts anywhere else scrolls the page.

## Test plan

- [x] Unit + CLI tests still pass (no Python surface touched; 67
      tests stay green).
- [x] JS in `GlyphCollectorUI.html` still parses cleanly.
- [x] Scripted mobile-viewport smoke (above).
- [ ] Manual confirmation on Firefox / Android from the reporter.
