### PR TITLE
fix(glyph-collector): wrap mobile header rows so page stops overflowing horizontally

### DIFF
--- a/GlyphCollectorUI/GlyphCollectorUI.html
+++ b/GlyphCollectorUI/GlyphCollectorUI.html
@@ -65,6 +65,13 @@
             header { padding: 0.75rem !important; gap: 0.5rem !important; }
             header h1 { font-size: 1rem !important; }
             header button { height: 2.5rem !important; padding: 0.25rem 0.5rem !important; }
+            /* Force every inner flex row in the header to wrap so the
+               toolbar doesn't blow out horizontally and drag the whole
+               page into a 1146 px wide scroll container. Individual
+               buttons stay at their natural width and wrap to the next
+               line as needed. */
+            header > div { flex-wrap: wrap !important; }
+            header > div > * { flex-shrink: 0; }
             #canvasContainer {
                 display: flex !important;
                 flex-direction: column !important;


### PR DESCRIPTION
## Summary

Follow-up to #5. Vertical scroll works now, but the page still
overflowed horizontally on mobile because the toolbar row inside
`<header>` never wrapped.

## Root cause

At a 412 px mobile viewport, measured via Playwright on the current
`main`:

```
body.scrollWidth   = 1146
header.scrollWidth = 1146
main.scrollWidth   =  412
```

The outer `<header class="flex flex-wrap ...">` wraps its own direct
children, but the inner toolbar row is a separate `<div class="flex
gap-4 items-end">` **without** `flex-wrap`. All ~14 buttons
(Settings, Save, Undo, Redo, Smooth, Bezier, Normalize, Template,
Reset, Connect, 📊, 👁) stayed in a single horizontal row and dragged
the whole body scroll container out to 1146 px wide.

`body { overflow-x: hidden }` from the earlier fix hid the scroll, so
the content just sat clipped off-screen.

## Fix

Inside the existing `@media (max-width: 900px)` block:

```css
header > div       { flex-wrap: wrap !important; }
header > div > *   { flex-shrink: 0; }
```

Every direct-child `<div>` of `<header>` now wraps, and their
children (buttons, inputs) keep their intrinsic widths instead of
squishing. Desktop is unaffected — the media query only fires below
900 px.

## Verification

Same 412 × 800 mobile viewport, same Playwright harness:

| Metric | Before | After |
|--------|--------|-------|
| `body.scrollWidth` | 1146 | **412** |
| `header.scrollWidth` | 1146 | **412** |
| `header` bbox height | 1 row (~60 px) | ~408 px (4 rows wrapping) |

The header grows vertically as the toolbar wraps to multiple rows,
which is the correct trade-off on a narrow phone: every button
stays tappable and nothing sits clipped off-screen. The earlier
vertical-scroll fix means the rest of the page scrolls into view
normally.

## Test plan

- [x] Playwright mobile-viewport smoke: no horizontal overflow.
- [x] JS still parses cleanly.
- [x] Desktop layout visually unchanged (media query only fires < 900 px).
- [ ] Manual confirmation on Firefox / Android from the reporter.
