### PR TITLE
fix(glyph-collector): wrap mobile header rows so page stops overflowi…

### DIFF
--- a/GlyphCollectorUI/GlyphCollectorUI.html
+++ b/GlyphCollectorUI/GlyphCollectorUI.html
@@ -65,6 +65,13 @@
             header { padding: 0.75rem !important; gap: 0.5rem !important; }
             header h1 { font-size: 1rem !important; }
             header button { height: 2.5rem !important; padding: 0.25rem 0.5rem !important; }
+            /* Force every inner flex row in the header to wrap so the
+               toolbar doesn't blow out horizontally and drag the whole
+               page into a 1146 px wide scroll container. Individual
+               buttons stay at their natural width and wrap to the next
+               line as needed. */
+            header > div { flex-wrap: wrap !important; }
+            header > div > * { flex-shrink: 0; }
             #canvasContainer {
                 display: flex !important;
                 flex-direction: column !important;


### PR DESCRIPTION
…ng horizontally

Follow-up to the vertical-scroll fix (#5). At a 412 px mobile viewport the body still reported scrollWidth = 1146 even after vertical scroll worked, because the toolbar <div> inside the <header> was a flex container *without* flex-wrap — all ~14 toolbar buttons stayed in a single horizontal row and dragged the body's scroll container out to 1146 px wide. The outer <header> had flex-wrap on it, which prevented the header's own direct children from overflowing, but didn't reach the inner button row.

Fix: inside the existing @media (max-width: 900px) block, force flex-wrap: wrap on every direct-child div of the header, and keep their children from shrinking so buttons stay tappable when the row wraps.

Verified at the same 412x800 mobile viewport via Playwright:

  Before: body.scrollWidth = 1146, header.scrollWidth = 1146
  After:  body.scrollWidth =  412, header.scrollWidth =  412

Header grows to ~408 px tall (toolbar wraps to 4 rows on a narrow phone), which is the correct trade-off for a no-horizontal-overflow layout. Desktop unaffected: the media query only fires below 900 px.