### PR TITLE
fix(glyph-collector): restore page scrolling on mobile touch screens

### DIFF
--- a/GlyphCollectorUI/GlyphCollectorUI.html
+++ b/GlyphCollectorUI/GlyphCollectorUI.html
@@ -10,9 +10,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Allura&family=Amatic+SC&family=Architects+Daughter&family=Caveat&family=Dancing+Script&family=Gochi+Hand&family=Great+Vibes&family=Handlee&family=Indie+Flower&family=Kalam&family=Pacifico&family=Patrick+Hand&family=Permanent+Marker&family=Pinyon+Script&family=Sacramento&family=Shadows+Into+Light&family=Tangerine&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
-        /* Disable touch actions to prevent scrolling while drawing */
+        /* Keep pull-to-refresh and elastic scroll out of the way,
+           but DO NOT disable touch-action globally — that also blocks
+           page scrolling on mobile. Each .canvas-slot carries its own
+           touch-action: none so drawing stays hijack-free. */
         body {
-            touch-action: none;
             overscroll-behavior: none;
         }
 
@@ -40,8 +42,26 @@
         /* GC11: mobile / tablet layout. Below 900 px wide, switch to a
            single-column, one-variant-at-a-time flow. The toolbar wraps
            aggressively and the settings / coverage panels become
-           full-width sheets pinned to the bottom of the viewport. */
+           full-width sheets pinned to the bottom of the viewport.
+
+           Also: allow the body AND the main drawing area to scroll
+           vertically so a stack of 10 slots remains reachable on a
+           touch screen. Tailwind's h-screen / overflow-hidden on
+           <body> and overflow-y-hidden on <main> would otherwise
+           clamp the viewport to one screenful. */
         @media (max-width: 900px) {
+            html, body {
+                height: auto !important;
+                min-height: 100vh !important;
+                overflow-y: auto !important;
+                overflow-x: hidden !important;
+                -webkit-overflow-scrolling: touch;
+            }
+            main {
+                overflow-y: visible !important;
+                overflow-x: hidden !important;
+                flex: none !important;
+            }
             header { padding: 0.75rem !important; gap: 0.5rem !important; }
             header h1 { font-size: 1rem !important; }
             header button { height: 2.5rem !important; padding: 0.25rem 0.5rem !important; }


### PR DESCRIPTION
The Collector was unscrollable on Firefox for Android (reported in production). Three overlapping CSS rules were fighting each other and clamping the viewport to one screenful:

1. body { touch-action: none } — blanket-blocked every touch gesture on the whole page, including page scroll, pinch, and pull. The intent was to prevent scroll *while drawing* on a canvas, but .canvas-slot already carries its own touch-action: none, so the body-level rule was redundant AND over-reaching.
2. Tailwind h-screen + overflow-hidden on <body> clamped the viewport to 100vh with no scroll container.
3. <main> had overflow-y-hidden; GC11's mobile reflow stacks 10 slots vertically, well past the viewport height, with no way to scroll them into view.

Fix:

- Drop the body-level touch-action: none. Keep overscroll-behavior: none on body so pull-to-refresh still doesn't hijack drawing.
- In the @media (max-width: 900px) block, override html / body to height: auto, min-height: 100vh, overflow-y: auto, with -webkit-overflow-scrolling: touch for iOS momentum.
- Same block: let <main> use overflow-y: visible and drop its flex: 1 so it doesn't compete with the body scroller.

Verified at a 412x800 mobile viewport (Playwright, touch + mobile emulation):
- body computed touch-action: 'auto' (was 'none').
- body computed overflow-y: 'auto'.
- document.scrollHeight = 4767, clientHeight = 800 — scrollable.
- window.scrollTo(0, 400) -> window.scrollY = 400 — actually scrolls.

Desktop is unaffected: the media query only kicks in below 900 px wide, and canvas drawing still blocks accidental scroll via the .canvas-slot touch-action: none.